### PR TITLE
Namespace directive - run digest after parsing

### DIFF
--- a/public/js/directives.js
+++ b/public/js/directives.js
@@ -71,7 +71,7 @@ angular.module('njax.directives', ['njax.services'])
                     namespace = namespace.replace(/ /g,"_");
                     if(element.val() != namespace){
                         element.val(namespace);
-
+			scope.$parent.$digest();
                     }
                 })
             }


### PR DESCRIPTION
This is necessary for a angular to detect a change when watching the element, used to check if namespace is unique.
